### PR TITLE
This will be a series of small scale and low risk changes for improving startup

### DIFF
--- a/src/main/java/bisq/common/setup/GracefulShutDownHandler.java
+++ b/src/main/java/bisq/common/setup/GracefulShutDownHandler.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.setup;
+
+import bisq.common.handlers.ResultHandler;
+
+public interface GracefulShutDownHandler {
+    void gracefulShutDown(ResultHandler resultHandler);
+}

--- a/src/main/java/bisq/common/setup/UncaughtExceptionHandler.java
+++ b/src/main/java/bisq/common/setup/UncaughtExceptionHandler.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.common.setup;
+
+public interface UncaughtExceptionHandler {
+    void handleUncaughtException(Throwable throwable, boolean doShutDown);
+}


### PR DESCRIPTION
Move guice setup to BisqAppMain 

- Add to onApplicationLaunched, setupGuice, setupPersistedDataHosts and gracefulShutDown methods to BisqExecutable
- Move CommonSetup.setup to BisqAppMain
- Add UncaughtExceptionHandler and GracefulShutDownHandler interfaces
- Replace BiConsumer in CommonSetup.setup with UncaughtExceptionHandler
- Use getter for BisqApp.shutDownHandler