### PR TITLE
Protobuffer exception handling

### DIFF
--- a/src/main/java/bisq/common/proto/ProtobufferException.java
+++ b/src/main/java/bisq/common/proto/ProtobufferException.java
@@ -15,17 +15,16 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.common.proto.network;
+package bisq.common.proto;
 
-import bisq.common.proto.ProtoResolver;
-import bisq.common.proto.ProtobufferException;
+import java.io.IOException;
 
-import io.bisq.generated.protobuffer.PB;
+public class ProtobufferException extends IOException {
+    public ProtobufferException(String message) {
+        super(message);
+    }
 
-public interface NetworkProtoResolver extends ProtoResolver {
-    NetworkEnvelope fromProto(PB.NetworkEnvelope proto) throws ProtobufferException;
-
-    NetworkPayload fromProto(PB.StoragePayload proto);
-
-    NetworkPayload fromProto(PB.StorageEntryWrapper proto);
+    public ProtobufferException(String message, Throwable e) {
+        super(message, e);
+    }
 }

--- a/src/main/java/bisq/common/proto/ProtobufferRuntimeException.java
+++ b/src/main/java/bisq/common/proto/ProtobufferRuntimeException.java
@@ -17,12 +17,12 @@
 
 package bisq.common.proto;
 
-public class ProtobufferException extends RuntimeException {
-    public ProtobufferException(String message) {
+public class ProtobufferRuntimeException extends RuntimeException {
+    public ProtobufferRuntimeException(String message) {
         super(message);
     }
 
-    public ProtobufferException(String message, Throwable e) {
+    public ProtobufferRuntimeException(String message, Throwable e) {
         super(message, e);
     }
 }


### PR DESCRIPTION
- Use ProtobufferException for
CoreNetworkProtoResolver.fromProto(PB.NetworkEnvelope proto)
- Add raw PB data in case if an exception
- log error if the encrypted data contains unknown PB data

Note: We should refactor the resolvers with checked exceptions instead
of the ProtobufferRuntimeException, but for the moment we leave that to
not add too much complexity/risk for that release.