### PR TITLE
Fix backward compatibility issues

### DIFF
--- a/src/main/java/bisq/common/app/Capabilities.java
+++ b/src/main/java/bisq/common/app/Capabilities.java
@@ -38,7 +38,8 @@ public class Capabilities {
         DAO_FULL_NODE,
         PROPOSAL,
         BLIND_VOTE,
-        ACK_MSG
+        ACK_MSG,
+        BSQ_BLOCK
     }
 
     // Application need to set supported capabilities at startup


### PR DESCRIPTION
- Add BSQ_BLOCK to capabilities for broadcast of new BSQ blocks
- Make NewBlockBroadcastMessage implements CapabilityRequiringPayload
- Call daoSetup.onAllServicesInitialized only if dao is activated
- Publish bsq block only after parsing is complete