### PR TITLE
Fix protobuffer definitions

### DIFF
--- a/src/main/java/bisq/common/storage/Storage.java
+++ b/src/main/java/bisq/common/storage/Storage.java
@@ -165,7 +165,7 @@ public class Storage<T extends PersistableEnvelope> {
                 log.error(t.getMessage());
                 try {
                     // We keep a backup which might be used for recovery
-                    fileManager.removeAndBackupFile(fileName);
+                    removeAndBackupFile(fileName);
                     DevEnv.logErrorAndThrowIfDevMode(t.toString());
                 } catch (IOException e1) {
                     e1.printStackTrace();
@@ -177,5 +177,9 @@ public class Storage<T extends PersistableEnvelope> {
             }
         }
         return null;
+    }
+
+    public void removeAndBackupFile(String fileName) throws IOException {
+        fileManager.removeAndBackupFile(fileName);
     }
 }

--- a/src/main/proto/pb.proto
+++ b/src/main/proto/pb.proto
@@ -912,15 +912,16 @@ message PersistableEnvelope {
         UserPayload user_payload = 10;
         PaymentAccountList payment_account_list = 11;
 
-        // we need to keep id 15 here otherwise the reading of the old data structure would not work anymore.
-        // can be removed after most people have updated as the reading of the PersistableNetworkPayloadList
-        // is not mandatory.
-        PersistableNetworkPayloadList persistable_network_payload_list = 12; // deprecated. Not used anymore.
+        BsqState bsq_state = 12;
 
         AccountAgeWitnessStore account_age_witness_store = 13;
         TradeStatistics2Store trade_statistics2_store = 14;
 
-        BsqState bsq_state = 15;
+        // we need to keep id 15 here otherwise the reading of the old data structure would not work anymore.
+        // can be removed after most people have updated as the reading of the PersistableNetworkPayloadList
+        // is not mandatory.
+        PersistableNetworkPayloadList persistable_network_payload_list = 15; // deprecated. Not used anymore.
+
         ProposalStore proposal_store = 16;
         TempProposalStore temp_proposal_store = 17;
         BlindVoteStore blind_vote_store = 18;

--- a/src/main/proto/pb.proto
+++ b/src/main/proto/pb.proto
@@ -912,16 +912,15 @@ message PersistableEnvelope {
         UserPayload user_payload = 10;
         PaymentAccountList payment_account_list = 11;
 
-        AccountAgeWitnessStore account_age_witness_store = 12;
-        TradeStatistics2Store trade_statistics2_store = 13;
-
-        BsqState bsq_state = 14;
-
         // we need to keep id 15 here otherwise the reading of the old data structure would not work anymore.
         // can be removed after most people have updated as the reading of the PersistableNetworkPayloadList
         // is not mandatory.
-        PersistableNetworkPayloadList persistable_network_payload_list = 15; // deprecated. Not used anymore.
+        PersistableNetworkPayloadList persistable_network_payload_list = 12; // deprecated. Not used anymore.
 
+        AccountAgeWitnessStore account_age_witness_store = 13;
+        TradeStatistics2Store trade_statistics2_store = 14;
+
+        BsqState bsq_state = 15;
         ProposalStore proposal_store = 16;
         TempProposalStore temp_proposal_store = 17;
         BlindVoteStore blind_vote_store = 18;


### PR DESCRIPTION
Deprecated PersistableNetworkPayloadList had initially the message type
number 12 and got changed to 15 which caused errors. We changed back so
that PersistableNetworkPayloadList has nr 12 again.
AccountAgeWitnessStore and TradeStatistics2Store also have been changed
to have the same numbers as on th latest release again.

Here are the items from the latest 0.7.1 release:
...
PersistableNetworkPayloadList persistable_network_payload_list = 12;
AccountAgeWitnessStore account_age_witness_store = 13;
TradeStatistics2Store trade_statistics2_store = 14;
State state = 15;
...

Here are the current items:
PersistableNetworkPayloadList persistable_network_payload_list = 12;
AccountAgeWitnessStore account_age_witness_store = 13;
TradeStatistics2Store trade_statistics2_store = 14;
BsqState bsq_state = 15;